### PR TITLE
mvebu: limit mvneta tx queue workaround to 32 bit SoC

### DIFF
--- a/target/linux/mvebu/patches-5.4/700-mvneta-tx-queue-workaround.patch
+++ b/target/linux/mvebu/patches-5.4/700-mvneta-tx-queue-workaround.patch
@@ -9,10 +9,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 ---
 --- a/drivers/net/ethernet/marvell/mvneta.c
 +++ b/drivers/net/ethernet/marvell/mvneta.c
-@@ -4691,6 +4691,14 @@ static int mvneta_ethtool_set_eee(struct
+@@ -4691,6 +4691,16 @@ static int mvneta_ethtool_set_eee(struct
  	return phylink_ethtool_set_eee(pp->phylink, eee);
  }
  
++#ifndef CONFIG_ARM64
 +static u16 mvneta_select_queue(struct net_device *dev, struct sk_buff *skb,
 +			       struct net_device *sb_dev)
 +{
@@ -20,15 +21,18 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	 * use only one queue until it is fixed */
 +	return 0;
 +}
++#endif
 +
  static const struct net_device_ops mvneta_netdev_ops = {
  	.ndo_open            = mvneta_open,
  	.ndo_stop            = mvneta_stop,
-@@ -4701,6 +4709,7 @@ static const struct net_device_ops mvnet
+@@ -4701,6 +4711,9 @@ static const struct net_device_ops mvnet
  	.ndo_fix_features    = mvneta_fix_features,
  	.ndo_get_stats64     = mvneta_get_stats64,
  	.ndo_do_ioctl        = mvneta_ioctl,
++#ifndef CONFIG_ARM64
 +	.ndo_select_queue    = mvneta_select_queue,
++#endif
  	.ndo_bpf             = mvneta_xdp,
  	.ndo_xdp_xmit        = mvneta_xdp_xmit,
  };


### PR DESCRIPTION
This patch has been carried since introduction throughout every kernel
major bump and no one has tested if the later kernels improved the
situation. The Armada 3720 SoC can only process GbE interrupts on Core 0
and this is already limited in all stable kernels, so ditch this
workaround for 64 bit SoCs.

Ref: https://git.kernel.org/torvalds/c/cf9bf871280d

Signed-off-by: Tomasz Maciej Nowak <tmn505@gmail.com>
(cherry picked from commit cbdd2b62e4d5e0572204c37d874d32dc8610840e)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
