### PR TITLE
ramips: add support for minew g1-c

### DIFF
--- a/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
+++ b/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Minew G1-C";
+	compatible = "minew,g1-c", "mediatek,mt7628an-soc";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "red:system";
+			gpios = <&gpio 43 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		ws2812 {
+			gpio-export,name = "ws2812";
+			gpio-export,output = <1>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		nrf_power {
+			gpio-export,name = "nrf_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 45 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio";
+		function = "gpio";
+	};
+
+	p0led_an {
+		groups = "p0led_an";
+		function = "gpio";
+	};
+
+	uart1 {
+		groups = "uart1";
+		function = "gpio";
+	};
+
+	wdt {
+		groups = "wdt";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&wmac {
+	status = "okay";
+};
+
+&sdhci {
+	status = "okay";
+	mediatek,cd-high;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -269,6 +269,15 @@ define Device/mercury_mac1200r-v2
 endef
 TARGET_DEVICES += mercury_mac1200r-v2
 
+define Device/minew_g1-c
+  IMAGE_SIZE := 15744k
+  DEVICE_VENDOR := Minew
+  DEVICE_MODEL := G1-C
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport kmod-usb-serial-cp210x
+  SUPPORTED_DEVICES += minew-g1c
+endef
+TARGET_DEVICES += minew_g1-c
+
 define Device/netgear_r6020
   $(Device/netgear_sercomm_nor)
   IMAGE_SIZE := 7104k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ramips_setup_interfaces()
 	glinet,vixmini|\
 	hak5,wifi-pineapple-mk7|\
 	mediatek,linkit-smart-7688|\
+	minew,g1-c|\
 	onion,omega2p|\
 	onion,omega2|\
 	ravpower,rp-wd009|\


### PR DESCRIPTION
The minew g1-c is a smart home gateway / BLE gateway.
A Nordic nRF52832 is available via USB UART (cp210x) to support BLE.
The LED ring is a ring of 24x ws2812b connect to a generic GPIO (unsupported).
There is a small LED which is only visible when the device is open which
will be used as LED until the ws2812b is supported.
The board has also a micro sdcard/tfcard slot (untested).
The Nordic nRF52832 exposes SWD over a 5pin header (GND, VCC, SWD, SWC, RST).
The vendor uses an older OpenWrt version, sysupgrade can be used via
serial or ssh.

CPU:		MT7628AN / 580MHz
RAM:		DDR2 128 MiB RAM
Flash:		SPI NOR 16 MiB W25Q128
Ethernet:	1x 100 mbit (Port 0) (PoE in)
USB:		USB hub, 2x external, 1x internal to USB UART
Power:		via micro usb or PoE 802.11af
UART:		3.3V, 115200 8n1

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
