### PR TITLE
ramips: minew g1-c: Allow dynamic RAM sizes

### DIFF
--- a/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
+++ b/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_system;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;


### PR DESCRIPTION
Allow RAM size to be passed thru U-Boot. There are 128MB and 64MB
versions of Minew G1-C. This is also in line with the behaviour of
most other RAMIPS boards.

Signed-off-by: Bruno Randolf <br1@einfach.org>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
