### PR TITLE
bcm4908: fix calculation of new cferam index

### DIFF
--- a/target/linux/bcm4908/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bcm4908/base-files/lib/upgrade/platform.sh
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
 
-RAMFS_COPY_BIN="bcm4908img"
+RAMFS_COPY_BIN="bcm4908img expr"
 
 PART_NAME=firmware
 
@@ -129,7 +129,7 @@ platform_calc_new_cferam() {
 	umount $dir
 	rm -fr $dir
 
-	idx=$(((idx + inc) % 1000))
+	idx=$(($(expr $idx + $inc) % 1000))
 
 	echo $(printf "cferam.%03d" $idx)
 }


### PR DESCRIPTION
The arithmetic expansion fails when idx becomes a two digit number.
Fix this by relying on expr command.

root@OpenWrt:/# echo $(((028 + 0) % 1000))
/bin/ash: arithmetic syntax error
root@OpenWrt:/# echo $(($(expr 028 + 0) % 1000))
28

Fixes: a6a0b252baa6 ("bcm4908: add sysupgrade support")
Signed-off-by: Sungbo Eo <mans0n@gorani.run>
(cherry picked from commit f4323538501d58298f4df73a034a51375a477cfc)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
