### PR TITLE
busybox: update to 1.33.2 bugfix release

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
-PKG_VERSION:=1.33.1
+PKG_VERSION:=1.33.2
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.busybox.net/downloads \
 		http://sources.buildroot.net
-PKG_HASH:=12cec6bd2b16d8a9446dd16130f2b92982f1819f6e1c5f5887b6db03f5660d28
+PKG_HASH:=6843ba7977081e735fa0fdb05893e3c002c8c5ad7c9c80da206e603cc0ac47e7
 
 PKG_BUILD_DEPENDS:=BUSYBOX_CONFIG_PAM:libpam
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Update busybox to 1.33.2, which includes only 5 commits after 1.33.1

  Bug fix release. 1.33.2 has fixes for hush and ash (parsing fixes)
  and unlzma (fix where we could read before beginning of buffer).

https://git.busybox.net/busybox/log/?h=1_33_2

Signed-off-by: Hannu Nyman <hannu.nyman@iki.fi>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
