### PR TITLE
hostapd: only attempt to set qos map if supported by the driver

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=37
+PKG_RELEASE:=38
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/patches/751-qos_map_ignore_when_unsupported.patch
+++ b/package/network/services/hostapd/patches/751-qos_map_ignore_when_unsupported.patch
@@ -1,0 +1,12 @@
+--- a/src/ap/ap_drv_ops.c
++++ b/src/ap/ap_drv_ops.c
+@@ -850,7 +850,8 @@ int hostapd_start_dfs_cac(struct hostapd
+ int hostapd_drv_set_qos_map(struct hostapd_data *hapd,
+ 			    const u8 *qos_map_set, u8 qos_map_set_len)
+ {
+-	if (!hapd->driver || !hapd->driver->set_qos_map || !hapd->drv_priv)
++	if (!hapd->driver || !hapd->driver->set_qos_map || !hapd->drv_priv ||
++	    !(hapd->iface->drv_flags & WPA_DRIVER_FLAGS_QOS_MAPPING))
+ 		return 0;
+ 	return hapd->driver->set_qos_map(hapd->drv_priv, qos_map_set,
+ 					 qos_map_set_len);


### PR DESCRIPTION
Fixes issues with brcmfmac

Signed-off-by: Felix Fietkau <nbd@nbd.name>
(cherry-picked from commit 5e67cd63c4ff5d8f36c341dfa3355e3a4ac2be81)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
