### PR TITLE
apm821xx: fix WD MyBook Live DUO USB-Port

### DIFF
--- a/target/linux/apm821xx/dts/wd-mybooklive.dts
+++ b/target/linux/apm821xx/dts/wd-mybooklive.dts
@@ -119,9 +119,11 @@
 	usbpwr: usb-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "Power USB Core";
-		gpios = <&GPIO1 2 GPIO_ACTIVE_LOW>;
+		gpios = <&GPIO1 2 GPIO_ACTIVE_HIGH>;
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
+		regulator-boot-on; /* uboot sets this */
+		enable-active-high;
 	};
 };
 

--- a/target/linux/apm821xx/patches-5.4/100-dwc2-disable-powerdown.patch
+++ b/target/linux/apm821xx/patches-5.4/100-dwc2-disable-powerdown.patch
@@ -1,0 +1,29 @@
+From 88ca61467a0897c79b1fbf8f5c30691b43b52613 Mon Sep 17 00:00:00 2001
+From: Christian Lamparter <chunkeey@gmail.com>
+Date: Sun, 26 Dec 2021 22:36:29 +0200
+Subject: [PATCH] dwc2: temporary force to be powered up all times
+
+the APM821xx's onchip dwc2 misbehaves with 5.4 and 5.10
+when a USB device gets connected. Instead of announcing
+and setting up the USB devices it crashes and burns with:
+
+[   22.023476] dwc2 4bff80000.usbotg: dwc2_restore_global_registers: no global registers to restore
+[   22.032245] dwc2 4bff80000.usbotg: dwc2_exit_partial_power_down: failed to restore registers
+[   22.040647] dwc2 4bff80000.usbotg: exit partial_power_down failed
+[   22.058765] dwc2 4bff80000.usbotg: HC died; cleaning up
+
+This is all seemingly fixed with dwc2 from a 5.16-rc6.
+
+Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
+---
+
+--- a/drivers/usb/dwc2/params.c
++++ b/drivers/usb/dwc2/params.c
+@@ -137,6 +137,7 @@ static void dwc2_set_amcc_params(struct
+ 	struct dwc2_core_params *p = &hsotg->params;
+ 
+ 	p->ahbcfg = GAHBCFG_HBSTLEN_INCR16 << GAHBCFG_HBSTLEN_SHIFT;
++	p->power_down = DWC2_POWER_DOWN_PARAM_NONE;
+ }
+ 
+ static void dwc2_set_stm32f4x9_fsotg_params(struct dwc2_hsotg *hsotg)


### PR DESCRIPTION
where to begin? the USB regulator settings were just
a part of the issue. With them changed, according to
the forum it still failed when a USB device was
connected to the port with:

dwc2 4bff80000.usbotg: dwc2_restore_global_registers: no global registers to restore
dwc2 4bff80000.usbotg: dwc2_exit_partial_power_down: failed to restore registers
dwc2 4bff80000.usbotg: exit partial_power_down failed
dwc2 4bff80000.usbotg: HC died; cleaning up

One clue was found upstream in
commit cc10ce0c51b1 ("usb: dwc2: disable power_down on Amlogic devices")

|Disable power_down by setting the parameter to
|DWC2_POWER_DOWN_PARAM_NONE. This fixes a problem on various Amlogic
|Meson SoCs where USB devices are only recognized when plugged in before
|booting Linux. A hot-plugged USB device was not detected even though the
|device got power (my USB thumb drive for example has an LED which lit
|up).
|[...]

the same method proposed there worked with APM821xx's USB IP-Core.

Link: https://forum.openwrt.org/t/wd-my-book-duo-usb/111926/2
Reported-by: thwe and takimata (openwrt forum)
Fixes: b70d3557e05 ("apm821xx: clean up gpio-hogs")
Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
(cherry picked from commit 832b9cbd741cdb6cc8483b2cddfef6de000ec61d)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
