### PR TITLE
nftables: allow quoted string in flowtable_expr_member

### DIFF
--- a/package/network/utils/nftables/Makefile
+++ b/package/network/utils/nftables/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nftables
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://netfilter.org/projects/$(PKG_NAME)/files

--- a/package/network/utils/nftables/patches/001-parser-allow-quoted-string-in-flowtable_expr_member.patch
+++ b/package/network/utils/nftables/patches/001-parser-allow-quoted-string-in-flowtable_expr_member.patch
@@ -1,0 +1,44 @@
+From 07af4429241c9832a613cb8620331ac54257d9df Mon Sep 17 00:00:00 2001
+From: Stijn Tintel <stijn@linux-ipv6.be>
+Date: Tue, 21 Dec 2021 12:40:25 +0200
+Subject: [PATCH] parser: allow quoted string in flowtable_expr_member
+
+Devices with interface names starting with a digit can not be configured
+in flowtables. Trying to do so throws the following error:
+
+Error: syntax error, unexpected number, expecting comma or '}'
+devices = { eth0, 6in4-wan6 };
+
+This is however a perfectly valid interface name. Solve the issue by
+allowing the use of quoted strings.
+
+Suggested-by: Jo-Philipp Wich <jo@mein.io>
+Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ src/parser_bison.y | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/parser_bison.y b/src/parser_bison.y
+index 16607bb7..1136ab91 100644
+--- a/src/parser_bison.y
++++ b/src/parser_bison.y
+@@ -2151,7 +2151,14 @@ flowtable_list_expr	:	flowtable_expr_member
+ 			|	flowtable_list_expr	COMMA	opt_newline
+ 			;
+ 
+-flowtable_expr_member	:	STRING
++flowtable_expr_member	:	QUOTED_STRING
++			{
++				$$ = constant_expr_alloc(&@$, &string_type,
++							 BYTEORDER_HOST_ENDIAN,
++							 strlen($1) * BITS_PER_BYTE, $1);
++				xfree($1);
++			}
++			|	STRING
+ 			{
+ 				$$ = constant_expr_alloc(&@$, &string_type,
+ 							 BYTEORDER_HOST_ENDIAN,
+-- 
+2.33.1
+


### PR DESCRIPTION
This is required to be able to use flow offloading on devices with
ifnames that start with a digit, like 6in4-wan6.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
