### PR TITLE
lantiq: flag FritzBox 7360 family buttons active-low

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -33,13 +33,13 @@
 
 		dect {
 			label = "dect";
-			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_PHONE>;
 		};
 
 		wifi {
 			label = "wifi";
-			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 		};
 	};


### PR DESCRIPTION
All buttons of the FritzBox 7360 family are active-low, not active-high.
Corrent the GPIO flag. This fixes release triggers upon push of a button.

Reported-by: Jan-Niklas Burfeind <git@aiyionpri.me>
Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit 31545378641d45f5fac5ffc408a31b700b80121f)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
