### PR TITLE
openssl: bump to 1.1.1n

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=m
+PKG_BUGFIX:=n
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -26,7 +26,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96
+PKG_HASH:=40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
This is a bugfix release. Changelog:

  *) Fixed a bug in the BN_mod_sqrt() function that can cause it to loop
     forever for non-prime moduli. (CVE-2022-0778)

  *) Add ciphersuites based on DHE_PSK (RFC 4279) and ECDHE_PSK
     (RFC 5489) to the list of ciphersuites providing Perfect Forward
     Secrecy as required by SECLEVEL >= 3.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
(cherry picked from commit e17c6ee62770005e398364ee5d955c9a8ab6f016)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
