### PR TITLE
ath79: fix TPLINK_HWREV field for TL-WR1043ND v4

### DIFF
--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -658,6 +658,7 @@ define Device/tplink_tl-wr1043nd-v4
   DEVICE_VARIANT := v4
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x10430004
+  TPLINK_HWREV := 0x1
   TPLINK_BOARD_ID := TLWR1043NDV4
   SUPPORTED_DEVICES += tl-wr1043nd-v4
 endef


### PR DESCRIPTION
Required to allow sysupgrades from OpenWrt 19.07.

Closes #7071

Fixes: 98fbf2edc021 ("ath79: move TPLINK_HWID/_HWREV to parent for tplink-safeloader")
Tested-by: J. Burfeind <git@aiyionpri.me>
Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
(cherry picked from commit 8ba71f1f6f2359f9cf54201e9fc037df33f123c0)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
