### PR TITLE
ath79: fix label MAC address for Ubiquiti UniFi AP Outdoor+

### DIFF
--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
@@ -7,7 +7,6 @@
 	model = "Ubiquiti UniFi AP Outdoor+";
 
 	aliases {
-		label-mac-device = &wifi;
 		led-boot = &led_white;
 		led-failsafe = &led_white;
 		led-running = &led_blue;

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
@@ -7,7 +7,6 @@
 	model = "Ubiquiti UniFi";
 
 	aliases {
-		label-mac-device = &eth0;
 		led-boot = &led_dome_green;
 		led-failsafe = &led_dome_green;
 		led-running = &led_dome_green;

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi.dtsi
@@ -6,6 +6,10 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	aliases {
+		label-mac-device = &eth0;
+	};
+
 	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;


### PR DESCRIPTION
The label has the MAC address of eth0, not the WLAN PHY address. We can
merge the definition back into ar7241_ubnt_unifi.dtsi, as both DTS
derived from it use the same interface for their label MAC addresses
after all.

Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
(cherry picked from commit aee9ccf5c1b536189ebee8c232273657334da843)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
