### PR TITLE
ath79: migrate Archer C5 5GHz radio device paths

### DIFF
--- a/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/00-wifi-migration
+++ b/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/00-wifi-migration
@@ -14,6 +14,7 @@ migrate_wifi_path() {
 			board=$(board_name)
 
 			case "$board" in
+				tplink,archer-c5-v1|\
 				tplink,archer-c7-v1|\
 				tplink,archer-c7-v2|\
 				zyxel,nbg6716)


### PR DESCRIPTION
When upgrading a TP-Link Archer C5 v1 from ar71xx to ath79,
the 5ghz radio stops working because the device path changed.

Same has been done for the Archer C7 before:

commit e19506f20618 ("ath79: migrate Archer C7 5GHz radio device paths")

Signed-off-by: Jan-Niklas Burfeind <git@aiyionpri.me>
(cherry picked from commit c6eb63d48f942f1e54737ed182776cf9a08de542)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
