### PR TITLE
imagebuilder: fix broken image generation with external targets

### DIFF
--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -78,7 +78,7 @@ ifneq ($(CONFIG_SIGNATURE_CHECK),)
 	$(CP) -L $(STAGING_DIR_ROOT)/usr/sbin/opkg-key $(PKG_BUILD_DIR)/scripts/
 endif
 
-	$(CP) $(TOPDIR)/target/linux $(PKG_BUILD_DIR)/target/
+	$(CP) -L $(TOPDIR)/target/linux $(PKG_BUILD_DIR)/target/
 	if [ -d $(TOPDIR)/staging_dir/host/lib/grub ]; then \
 		$(CP) $(TOPDIR)/staging_dir/host/lib/grub/ $(PKG_BUILD_DIR)/staging_dir/host/lib; \
 	fi


### PR DESCRIPTION
When using external targets there is a symlink being created for the
target under target/linux which then becomes dangling under Image
Builder. Fix it by dereferencing the possible symlink.

Tested on IB with external target, ipq40xx and mvebu.

Signed-off-by: Petr Štetiar <ynezz@true.cz>
(cherry picked from commit 621f39d1f438bf95dbae667c575926fa16a6d797)
(cherry picked from commit ec9af870f3278f75549836b469baefa260e2ed41)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
