### PR TITLE
kernel: move Toshiba-TC58NVG0S3H patch to ipq40xx

### DIFF
--- a/target/linux/ipq40xx/patches-5.10/444-mtd-nand-rawnand-add-support-for-Toshiba-TC58NVG0S3H.patch
+++ b/target/linux/ipq40xx/patches-5.10/444-mtd-nand-rawnand-add-support-for-Toshiba-TC58NVG0S3H.patch
@@ -13,6 +13,7 @@ has 128 bytes OOB. This adds a static NAND ID entry to correct this.
 Tested on FRITZ!Box 7530 flashed with OpenWrt.
 
 Signed-off-by: Andreas Böhler <dev@aboehler.at>
+(changed id_len to 8, added comment about possible counterfeits)
 ---
  drivers/mtd/nand/raw/nand_ids.c | 3 +++
  1 file changed, 3 insertions(+)
@@ -23,9 +24,9 @@ Signed-off-by: Andreas Böhler <dev@aboehler.at>
  	{"TC58NVG0S3E 1G 3.3V 8-bit",
  		{ .id = {0x98, 0xd1, 0x90, 0x15, 0x76, 0x14, 0x01, 0x00} },
  		  SZ_2K, SZ_128, SZ_128K, 0, 8, 64, NAND_ECC_INFO(1, SZ_512), },
-+	{"TC58NVG0S3HTA00 1G 3.3V 8-bit",
-+		{ .id = {0x98, 0xf1, 0x80, 0x15} },
-+		  SZ_2K, SZ_128, SZ_128K, 0, 4, 128, NAND_ECC_INFO(8, SZ_512), },
++	{"TC58NVG0S3HTA00 1G 3.3V 8-bit", /* possibly counterfeit chip - see commit */
++		{ .id = {0x98, 0xf1, 0x80, 0x15} /* should be more bytes */ },
++		  SZ_2K, SZ_128, SZ_128K, 0, 8, 128, NAND_ECC_INFO(8, SZ_512), },
  	{"TC58NVG2S0F 4G 3.3V 8-bit",
  		{ .id = {0x98, 0xdc, 0x90, 0x26, 0x76, 0x15, 0x01, 0x08} },
  		  SZ_4K, SZ_512, SZ_256K, 0, 8, 224, NAND_ECC_INFO(4, SZ_512) },


### PR DESCRIPTION
Hannu Nyman wrote in openwrt's github issue #9962:
|Based on forum discussion, the commit 0bc794a
|"kernel: add support for Toshiba TC58NVG0S3HTA00 NAND flash"
|causes flash memory chip misdetection for some other
|Fritzbox devices, as the commit only defines a 4-byte flash
|memory chip ID that matches several chips used in the devices.
|
|See discussion from this onward
|<https://forum.openwrt.org/t/openwrt-22-03-0-rc1-first-release-candidate/126045/182>
|
|OpenWrt 22.03.0-rc2 and rc3 are causing on a Fritzbox 7412
|bootloops due to a misdetected flash chip.
|
|Yup, that patch is missing the 5th ID byte entirely - both chips
|share the same first 4;
|
| TC58NVG0S3HTA00 = 0x98 0xf1 0x80 0x15 0x72 (digikey datasheet, page 35)
| TC58BVG0S3HTA00 = 0x98 0xf1 0x80 0x15 0xf2 (digikey datasheet, page 28)
|
|The commit has also been backported to openwrt-22.03 after rc1,
|so both rc2 and rc3 suffer from this bug."

Andreas' TC58NVG0S3H seems not to follow Toshibas/Kioxa's own datasheet.
It only reports the first four bytes: "98 f1 80 15 00 00 00 00".

This patch changes the id_len in the entry to 8. This makes it so that
Andreas' NAND is still detected. At the same time, this prevents other
Toshiba NAND flash chips - that share the same four bytes - from being
misdetected.

Upstream (Miquel Raynal) decided to drop this patch for now. But he
advised to keep it in OpenWrt. As other devices could be affected.
<https://lore.kernel.org/linux-mtd/20220606155919.23001410@xps-13/>

Reported-by: Peter-vdL
Tested-by: Peter-vdL
Tested-by: Andreas B<C3><B6>hler <dev@aboehler.at>
Fixes: 0bc794a66845 ("kernel: add support for Toshiba TC58NVG0S3HTA00 NAND flash")
Link: <https://github.com/openwrt/openwrt/issues/9962>
(actually move the patch, added comment about possible counterfeits)
Signed-off-by: Christian Lamparter <chunkeey@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
