### PR TITLE
hostapd: add owe_transition_ifname

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -335,6 +335,7 @@ hostapd_common_add_bss_config() {
 	config_add_int sae_pwe
 
 	config_add_string 'owe_transition_bssid:macaddr' 'owe_transition_ssid:string'
+	config_add_string owe_transition_ifname
 
 	config_add_boolean iw_enabled iw_internet iw_asra iw_esr iw_uesa
 	config_add_int iw_access_network_type iw_venue_group iw_venue_type
@@ -635,10 +636,11 @@ hostapd_set_bss_options() {
 
 	case "$auth_type" in
 		none|owe)
-			json_get_vars owe_transition_bssid owe_transition_ssid
+			json_get_vars owe_transition_bssid owe_transition_ssid owe_transition_ifname
 
 			[ -n "$owe_transition_ssid" ] && append bss_conf "owe_transition_ssid=\"$owe_transition_ssid\"" "$N"
 			[ -n "$owe_transition_bssid" ] && append bss_conf "owe_transition_bssid=$owe_transition_bssid" "$N"
+			[ -n "$owe_transition_ifname" ] && append bss_conf "owe_transition_ifname=$owe_transition_ifname" "$N"
 
 			wps_possible=1
 			# Here we make the assumption that if we're in open mode


### PR DESCRIPTION
Add the owe_transition_ifname config option to wifi-ifaces.

This allows to configure OWE transition VAPs without adding SSID / BSSID
to the uci conifg but instead autodiscovering these parameters from
other networks on the same PHY.

The following configuration creates a OWE transition mode network
constellation.

config wifi-iface 'open0'
	option device 'radio0'
	option ifname 'open0'
	option network 'lan'
	option mode 'ap'
	option ssid 'FreeNet'
	option encryption 'none'
	option owe_transition_ifname 'owe0'

config wifi-iface 'owe0'
	option device 'radio0'
	option ifname 'owe0'
	option network 'lan'
	option mode 'ap'
	option ssid 'owe_tm.FreeNet'
	option encryption 'owe'
	option hidden '1'
	option owe_transition_ifname 'open0'

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit 574539ee2cdbb3dd54086423c6dfdd19bb1c06a6)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
