### PR TITLE
ramips: fix RT-AC57U button level

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ac57u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ac57u.dts
@@ -37,7 +37,7 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio 43 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 			debounce-interval = <60>;
 		};


### PR DESCRIPTION
Both buttons on the RT-AC57U are active-low. Fix the GPIO flag for the
WPS cutton to fix button behavior.

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit 535b0c70b1c466733b009144f81f5207f1ecd311)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
