### PR TITLE
ramips: fix booting on ZyXEL NBG-419N v2

### DIFF
--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1237,6 +1237,7 @@ endef
 TARGET_DEVICES += zyxel_nbg-419n
 
 define Device/zyxel_nbg-419n-v2
+  $(Device/uimage-lzma-loader)
   SOC := rt3352
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ZyXEL


### PR DESCRIPTION
This fixes a well known "LZMA ERROR 1" error, reported previously on
numerous of other devices from 'ramips' target.

Fixes: #9842
Fixes: #8964

Reported-by: Juergen Hench <jurgen.hench@gmail.com>
Tested-by: Juergen Hench <jurgen.hench@gmail.com>
Signed-off-by: Demetris Ierokipides <ierokipides.dem@gmail.com>
Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
(cherry picked from commit fd72e595c2b2a46bab8cbc7e9415fbfeae7b5b0d)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
