### PR TITLE
build: fix ldconfig executable error in python

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -196,5 +196,4 @@ prereq: $(STAGING_DIR_HOST)/bin/mkhash
 
 # Install ldconfig stub
 $(eval $(call TestHostCommand,ldconfig-stub,Failed to install stub, \
-	touch $(STAGING_DIR_HOST)/bin/ldconfig && \
-	chmod +x $(STAGING_DIR_HOST)/bin/ldconfig))
+	$(LN) /bin/true $(STAGING_DIR_HOST)/bin/ldconfig))


### PR DESCRIPTION
The empty executable is causing problems with meson builds, due to the
error: OSError: [Errno 8] Exec format error: 'ldconfig'

This patch changes the empty ldconfig stub to symlink to /bin/true to
work around this issue.

Fixes: FS#4117
Fixes: 3bd31cc4d2ff ("tools/meson: update to 0.60.0")

Signed-off-by: Damien Mascord <tusker@tusker.org>
Tested-by: Aleksander Jan Bajkowski <olek2@wp.pl> # Tested on Debian 11
Tested-By: Lucian Cristian <lucian.cristian@gmail.com>
Tested-By: Baptiste Jonglez <git@bitsofnetworks.org>
Cc: Rosen Penev <rosenp@gmail.com>
(cherry picked from commit 6a5b4228e30244b44a49f523dea66caf3fbe3307)
Signed-off-by: Baptiste Jonglez <git@bitsofnetworks.org>
[backport to fix prereq check when moving from 22.03 branch to 21.02]

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
