### PR TITLE
mac80211: fix AQL issue with multicast traffic

### DIFF
--- a/package/kernel/mac80211/patches/subsys/339-mac80211-exclude-multicast-packets-from-AQL-pending-.patch
+++ b/package/kernel/mac80211/patches/subsys/339-mac80211-exclude-multicast-packets-from-AQL-pending-.patch
@@ -1,0 +1,30 @@
+From: Felix Fietkau <nbd@nbd.name>
+Date: Wed, 13 Jul 2022 07:32:26 +0200
+Subject: [PATCH] mac80211: exclude multicast packets from AQL pending airtime
+
+In AP mode, multicast traffic is handled very differently from normal traffic,
+especially if at least one client is in powersave mode.
+This means that multicast packets can be buffered a lot longer than normal
+unicast packets, and can eat up the AQL budget very quickly because of the low
+data rate.
+Along with the recent change to maintain a global PHY AQL limit, this can lead
+to significant latency spikes for unicast traffic.
+
+Since queueing multicast to hardware is currently not constrained by AQL limits
+anyway, let's just exclude it from the AQL pending airtime calculation entirely.
+
+Fixes: 8e4bac067105 ("wifi: mac80211: add a per-PHY AQL limit to improve fairness")
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+---
+
+--- a/net/mac80211/tx.c
++++ b/net/mac80211/tx.c
+@@ -3792,7 +3792,7 @@ begin:
+ encap_out:
+ 	IEEE80211_SKB_CB(skb)->control.vif = vif;
+ 
+-	if (vif &&
++	if (tx.sta &&
+ 	    wiphy_ext_feature_isset(local->hw.wiphy, NL80211_EXT_FEATURE_AQL)) {
+ 		bool ampdu = txq->ac != IEEE80211_AC_VO;
+ 		u32 airtime;


### PR DESCRIPTION
Exclude multicast from pending AQL budget

Signed-off-by: Felix Fietkau <nbd@nbd.name>
(cherry-picked from commit 9f1d6223289b5571ddc77c0e5327ab51137199d9)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
