### PR TITLE
octeon: add SUPPORTED_DEVICES to er/erlite

### DIFF
--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -48,6 +48,7 @@ define Device/ubnt_edgerouter
   DEVICE_MODEL := EdgeRouter
   BOARD_NAME := er
   CMDLINE := $(ER_CMDLINE)
+  SUPPORTED_DEVICES += er
 endef
 TARGET_DEVICES += ubnt_edgerouter
 
@@ -68,6 +69,7 @@ define Device/ubnt_edgerouter-lite
   DEVICE_MODEL := EdgeRouter Lite
   BOARD_NAME := erlite
   CMDLINE := $(ERLITE_CMDLINE)
+  SUPPORTED_DEVICES += erlite
 endef
 TARGET_DEVICES += ubnt_edgerouter-lite
 


### PR DESCRIPTION
Using the BOARD_NAME variable results for both er and erlite devices to
identify themselfs as `er` and `erlite` (via `ubus call system board`).

This is problematic when devices search for firmware upgrades since the
OpenWrt profile is actually called `ubnt_edgerouter` and
`ubnt_edgerouter-lite`.

By adding the `SUPPORTED_DEVICE` a mapping is created to point devices
called `er` or `erlite` to the corresponding profile.

FIXES: https://github.com/openwrt/asu/issues/348

Signed-off-by: Paul Spooren <mail@aparcar.org>
(cherry picked from commit 2a07270180ed0e295d854d6e9e59c78c40549efc)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
