### PR TITLE
mac80211: disable ft-over-ds by default

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -798,7 +798,7 @@ hostapd_set_bss_options() {
 			json_get_vars mobility_domain ft_psk_generate_local ft_over_ds reassociation_deadline
 
 			set_default mobility_domain "$(echo "$ssid" | md5sum | head -c 4)"
-			set_default ft_over_ds 1
+			set_default ft_over_ds 0
 			set_default reassociation_deadline 1000
 
 			case "$auth_type" in


### PR DESCRIPTION
Testing has shown it to be very unreliable in variety of configurations.
It is not mandatory, so let's disable it by default until we have a better
solution.

Signed-off-by: Felix Fietkau <nbd@nbd.name>
(cherry-picked from commit 2984a0420649733662ff95b0aff720b8c2c19f8a)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
