### PR TITLE
kernel: bump 5.4 to 5.4.213

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .211
+LINUX_VERSION-5.4 = .213
 
-LINUX_KERNEL_HASH-5.4.211 = bfb43241b72cd55797af68bea1cebe630d37664c0f9a99b6e9263a63a67e2dec
+LINUX_KERNEL_HASH-5.4.213 = e67ce168477e580375a80f3caef16819a85b15faa2d382adc6df18a62ad6baf1
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/apm821xx/patches-5.4/802-usb-xhci-force-msi-renesas-xhci.patch
+++ b/target/linux/apm821xx/patches-5.4/802-usb-xhci-force-msi-renesas-xhci.patch
@@ -23,7 +23,7 @@ produce a noisy warning.
  		xhci->quirks |= XHCI_RESET_ON_RESUME;
 --- a/drivers/usb/host/xhci.c
 +++ b/drivers/usb/host/xhci.c
-@@ -425,10 +425,14 @@ static int xhci_try_enable_msi(struct us
+@@ -427,10 +427,14 @@ static int xhci_try_enable_msi(struct us
  		free_irq(hcd->irq, hcd);
  	hcd->irq = 0;
  

--- a/target/linux/ath79/patches-5.4/910-unaligned_access_hacks.patch
+++ b/target/linux/ath79/patches-5.4/910-unaligned_access_hacks.patch
@@ -706,7 +706,7 @@
  EXPORT_SYMBOL(xfrm_parse_spi);
 --- a/net/ipv4/tcp_input.c
 +++ b/net/ipv4/tcp_input.c
-@@ -3986,14 +3986,16 @@ static bool tcp_parse_aligned_timestamp(
+@@ -3997,14 +3997,16 @@ static bool tcp_parse_aligned_timestamp(
  {
  	const __be32 *ptr = (const __be32 *)(th + 1);
  

--- a/target/linux/bcm27xx/patches-5.4/950-0089-cgroup-Disable-cgroup-memory-by-default.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0089-cgroup-Disable-cgroup-memory-by-default.patch
@@ -17,7 +17,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 
 --- a/kernel/cgroup/cgroup.c
 +++ b/kernel/cgroup/cgroup.c
-@@ -5797,6 +5797,9 @@ int __init cgroup_init_early(void)
+@@ -5860,6 +5860,9 @@ int __init cgroup_init_early(void)
  	return 0;
  }
  
@@ -27,7 +27,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
  /**
   * cgroup_init - cgroup initialization
   *
-@@ -5835,6 +5838,12 @@ int __init cgroup_init(void)
+@@ -5898,6 +5901,12 @@ int __init cgroup_init(void)
  
  	mutex_unlock(&cgroup_mutex);
  
@@ -40,7 +40,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
  	for_each_subsys(ss, ssid) {
  		if (ss->early_init) {
  			struct cgroup_subsys_state *css =
-@@ -6244,6 +6253,10 @@ static int __init cgroup_disable(char *s
+@@ -6307,6 +6316,10 @@ static int __init cgroup_disable(char *s
  			    strcmp(token, ss->legacy_name))
  				continue;
  
@@ -51,7 +51,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
  			static_branch_disable(cgroup_subsys_enabled_key[i]);
  			pr_info("Disabling %s control group subsystem\n",
  				ss->name);
-@@ -6253,6 +6266,31 @@ static int __init cgroup_disable(char *s
+@@ -6316,6 +6329,31 @@ static int __init cgroup_disable(char *s
  }
  __setup("cgroup_disable=", cgroup_disable);
  

--- a/target/linux/bcm27xx/patches-5.4/950-0218-usb-add-plumbing-for-updating-interrupt-endpoint-int.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0218-usb-add-plumbing-for-updating-interrupt-endpoint-int.patch
@@ -70,7 +70,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
   * @dev: the device whose endpoint is being disabled
 --- a/include/linux/usb.h
 +++ b/include/linux/usb.h
-@@ -1816,6 +1816,8 @@ extern int usb_clear_halt(struct usb_dev
+@@ -1818,6 +1818,8 @@ extern int usb_clear_halt(struct usb_dev
  extern int usb_reset_configuration(struct usb_device *dev);
  extern int usb_set_interface(struct usb_device *dev, int ifnum, int alternate);
  extern void usb_reset_endpoint(struct usb_device *dev, unsigned int epaddr);

--- a/target/linux/bcm27xx/patches-5.4/950-0219-xhci-implement-xhci_fixup_endpoint-for-interval-adju.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0219-xhci-implement-xhci_fixup_endpoint-for-interval-adju.patch
@@ -15,7 +15,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
 
 --- a/drivers/usb/host/xhci.c
 +++ b/drivers/usb/host/xhci.c
-@@ -1494,6 +1494,103 @@ command_cleanup:
+@@ -1485,6 +1485,103 @@ command_cleanup:
  }
  
  /*
@@ -119,7 +119,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
   * non-error returns are a promise to giveback() the urb later
   * we drop ownership so next owner (or urb unlink) can get it
   */
-@@ -5395,6 +5492,7 @@ static const struct hc_driver xhci_hc_dr
+@@ -5386,6 +5483,7 @@ static const struct hc_driver xhci_hc_dr
  	.endpoint_reset =	xhci_endpoint_reset,
  	.check_bandwidth =	xhci_check_bandwidth,
  	.reset_bandwidth =	xhci_reset_bandwidth,

--- a/target/linux/bcm27xx/patches-5.4/950-0519-clk-bcm-rpi-Add-clock-id-to-data.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0519-clk-bcm-rpi-Add-clock-id-to-data.patch
@@ -44,7 +44,7 @@ Signed-off-by: Maxime Ripard <maxime@cerno.tech>
 -					 &val);
 +					 data->id, &val);
  	if (ret)
- 		return ret;
+ 		return 0;
  
 @@ -133,8 +133,7 @@ static int raspberrypi_fw_pll_set_rate(s
  

--- a/target/linux/bcm27xx/patches-5.4/950-0520-clk-bcm-rpi-Pass-the-clocks-data-to-the-firmware-fun.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0520-clk-bcm-rpi-Pass-the-clocks-data-to-the-firmware-fun.patch
@@ -57,7 +57,7 @@ Signed-off-by: Maxime Ripard <maxime@cerno.tech>
 +	ret = raspberrypi_clock_property(rpi->firmware, data,
 +					 RPI_FIRMWARE_GET_CLOCK_RATE, &val);
  	if (ret)
- 		return ret;
+ 		return 0;
  
 @@ -131,9 +130,9 @@ static int raspberrypi_fw_pll_set_rate(s
  	u32 new_rate = rate / RPI_FIRMWARE_PLLB_ARM_DIV_RATE;

--- a/target/linux/bcm27xx/patches-5.4/950-0522-clk-bcm-rpi-Split-pllb-clock-hooks.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0522-clk-bcm-rpi-Split-pllb-clock-hooks.patch
@@ -31,7 +31,7 @@ Signed-off-by: Maxime Ripard <maxime@cerno.tech>
  		container_of(hw, struct raspberrypi_clk_data, hw);
 @@ -118,21 +118,27 @@ static unsigned long raspberrypi_fw_pll_
  	if (ret)
- 		return ret;
+ 		return 0;
  
 -	return val * RPI_FIRMWARE_PLLB_ARM_DIV_RATE;
 +	return val;

--- a/target/linux/bcm53xx/patches-5.4/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
+++ b/target/linux/bcm53xx/patches-5.4/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
@@ -40,7 +40,7 @@ it on BCM4708 family.
  /* called during probe() after chip reset completes */
 --- a/drivers/usb/host/xhci.c
 +++ b/drivers/usb/host/xhci.c
-@@ -156,6 +156,49 @@ int xhci_start(struct xhci_hcd *xhci)
+@@ -158,6 +158,49 @@ int xhci_start(struct xhci_hcd *xhci)
  	return ret;
  }
  
@@ -90,7 +90,7 @@ it on BCM4708 family.
  /*
   * Reset a halted HC.
   *
-@@ -606,10 +649,20 @@ static int xhci_init(struct usb_hcd *hcd
+@@ -608,10 +651,20 @@ static int xhci_init(struct usb_hcd *hcd
  
  static int xhci_run_finished(struct xhci_hcd *xhci)
  {
@@ -114,7 +114,7 @@ it on BCM4708 family.
  	xhci->shared_hcd->state = HC_STATE_RUNNING;
  	xhci->cmd_ring_state = CMD_RING_STATE_RUNNING;
  
-@@ -619,6 +672,10 @@ static int xhci_run_finished(struct xhci
+@@ -621,6 +674,10 @@ static int xhci_run_finished(struct xhci
  	xhci_dbg_trace(xhci, trace_xhci_dbg_init,
  			"Finished xhci_run for USB3 roothub");
  	return 0;

--- a/target/linux/generic/backport-5.4/600-v5.12-net-extract-napi-poll-functionality-to-__napi_poll.patch
+++ b/target/linux/generic/backport-5.4/600-v5.12-net-extract-napi-poll-functionality-to-__napi_poll.patch
@@ -18,7 +18,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -6325,15 +6325,10 @@ void netif_napi_del(struct napi_struct *
+@@ -6326,15 +6326,10 @@ void netif_napi_del(struct napi_struct *
  }
  EXPORT_SYMBOL(netif_napi_del);
  
@@ -35,7 +35,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	weight = n->weight;
  
  	/* This NAPI_STATE_SCHED test is for avoiding a race
-@@ -6351,7 +6346,7 @@ static int napi_poll(struct napi_struct
+@@ -6352,7 +6347,7 @@ static int napi_poll(struct napi_struct
  	WARN_ON_ONCE(work > weight);
  
  	if (likely(work < weight))
@@ -44,7 +44,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  	/* Drivers must not modify the NAPI state if they
  	 * consume the entire weight.  In such cases this code
-@@ -6360,7 +6355,7 @@ static int napi_poll(struct napi_struct
+@@ -6361,7 +6356,7 @@ static int napi_poll(struct napi_struct
  	 */
  	if (unlikely(napi_disable_pending(n))) {
  		napi_complete(n);
@@ -53,7 +53,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	}
  
  	if (n->gro_bitmask) {
-@@ -6378,12 +6373,29 @@ static int napi_poll(struct napi_struct
+@@ -6379,12 +6374,29 @@ static int napi_poll(struct napi_struct
  	if (unlikely(!list_empty(&n->poll_list))) {
  		pr_warn_once("%s: Budget exhausted after napi rescheduled\n",
  			     n->dev ? n->dev->name : "backlog");

--- a/target/linux/generic/backport-5.4/601-v5.12-net-implement-threaded-able-napi-poll-loop-support.patch
+++ b/target/linux/generic/backport-5.4/601-v5.12-net-implement-threaded-able-napi-poll-loop-support.patch
@@ -131,7 +131,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  static int __dev_open(struct net_device *dev, struct netlink_ext_ack *extack)
  {
  	const struct net_device_ops *ops = dev->netdev_ops;
-@@ -3888,6 +3910,21 @@ int gro_normal_batch __read_mostly = 8;
+@@ -3889,6 +3911,21 @@ int gro_normal_batch __read_mostly = 8;
  static inline void ____napi_schedule(struct softnet_data *sd,
  				     struct napi_struct *napi)
  {
@@ -153,7 +153,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	list_add_tail(&napi->poll_list, &sd->poll_list);
  	__raise_softirq_irqoff(NET_RX_SOFTIRQ);
  }
-@@ -6279,6 +6316,12 @@ void netif_napi_add(struct net_device *d
+@@ -6280,6 +6317,12 @@ void netif_napi_add(struct net_device *d
  	set_bit(NAPI_STATE_NPSVC, &napi->state);
  	list_add_rcu(&napi->dev_list, &dev->napi_list);
  	napi_hash_add(napi);
@@ -166,7 +166,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  }
  EXPORT_SYMBOL(netif_napi_add);
  
-@@ -6295,9 +6338,28 @@ void napi_disable(struct napi_struct *n)
+@@ -6296,9 +6339,28 @@ void napi_disable(struct napi_struct *n)
  	hrtimer_cancel(&n->timer);
  
  	clear_bit(NAPI_STATE_DISABLE, &n->state);
@@ -195,7 +195,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  static void flush_gro_hash(struct napi_struct *napi)
  {
  	int i;
-@@ -6322,6 +6384,11 @@ void netif_napi_del(struct napi_struct *
+@@ -6323,6 +6385,11 @@ void netif_napi_del(struct napi_struct *
  
  	flush_gro_hash(napi);
  	napi->gro_bitmask = 0;
@@ -207,7 +207,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  }
  EXPORT_SYMBOL(netif_napi_del);
  
-@@ -6401,6 +6468,51 @@ static int napi_poll(struct napi_struct
+@@ -6402,6 +6469,51 @@ static int napi_poll(struct napi_struct
  	return work;
  }
  

--- a/target/linux/generic/backport-5.4/602-v5.12-net-add-sysfs-attribute-to-control-napi-threaded-mod.patch
+++ b/target/linux/generic/backport-5.4/602-v5.12-net-add-sysfs-attribute-to-control-napi-threaded-mod.patch
@@ -57,7 +57,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
   *	@n: NAPI context
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -3914,8 +3914,9 @@ static inline void ____napi_schedule(str
+@@ -3915,8 +3915,9 @@ static inline void ____napi_schedule(str
  
  	if (test_bit(NAPI_STATE_THREADED, &napi->state)) {
  		/* Paired with smp_mb__before_atomic() in
@@ -69,7 +69,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		 * wake_up_process() when it's not NULL.
  		 */
  		thread = READ_ONCE(napi->thread);
-@@ -6293,6 +6294,49 @@ static void init_gro_hash(struct napi_st
+@@ -6294,6 +6295,49 @@ static void init_gro_hash(struct napi_st
  	napi->gro_bitmask = 0;
  }
  

--- a/target/linux/generic/backport-5.4/603-v5.12-net-fix-race-between-napi-kthread-mode-and-busy-poll.patch
+++ b/target/linux/generic/backport-5.4/603-v5.12-net-fix-race-between-napi-kthread-mode-and-busy-poll.patch
@@ -45,7 +45,7 @@ Cc: Hannes Frederic Sowa <hannes@stressinduktion.org>
  enum gro_result {
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -3921,6 +3921,8 @@ static inline void ____napi_schedule(str
+@@ -3922,6 +3922,8 @@ static inline void ____napi_schedule(str
  		 */
  		thread = READ_ONCE(napi->thread);
  		if (thread) {
@@ -54,7 +54,7 @@ Cc: Hannes Frederic Sowa <hannes@stressinduktion.org>
  			wake_up_process(thread);
  			return;
  		}
-@@ -6081,7 +6083,8 @@ bool napi_complete_done(struct napi_stru
+@@ -6082,7 +6084,8 @@ bool napi_complete_done(struct napi_stru
  
  		WARN_ON_ONCE(!(val & NAPIF_STATE_SCHED));
  
@@ -64,7 +64,7 @@ Cc: Hannes Frederic Sowa <hannes@stressinduktion.org>
  
  		/* If STATE_MISSED was set, leave STATE_SCHED set,
  		 * because we will call napi->poll() one more time.
-@@ -6514,16 +6517,25 @@ static int napi_poll(struct napi_struct
+@@ -6515,16 +6518,25 @@ static int napi_poll(struct napi_struct
  
  static int napi_thread_wait(struct napi_struct *napi)
  {

--- a/target/linux/generic/backport-5.4/604-v5.12-net-fix-hangup-on-napi_disable-for-threaded-napi.patch
+++ b/target/linux/generic/backport-5.4/604-v5.12-net-fix-hangup-on-napi_disable-for-threaded-napi.patch
@@ -34,7 +34,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -6521,7 +6521,7 @@ static int napi_thread_wait(struct napi_
+@@ -6522,7 +6522,7 @@ static int napi_thread_wait(struct napi_
  
  	set_current_state(TASK_INTERRUPTIBLE);
  
@@ -43,7 +43,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		/* Testing SCHED_THREADED bit here to make sure the current
  		 * kthread owns this napi and could poll on this napi.
  		 * Testing SCHED bit is not enough because SCHED bit might be
-@@ -6539,6 +6539,7 @@ static int napi_thread_wait(struct napi_
+@@ -6540,6 +6540,7 @@ static int napi_thread_wait(struct napi_
  		set_current_state(TASK_INTERRUPTIBLE);
  	}
  	__set_current_state(TASK_RUNNING);

--- a/target/linux/generic/backport-5.4/700-v5.5-net-core-allow-fast-GRO-for-skbs-with-Ethernet-heade.patch
+++ b/target/linux/generic/backport-5.4/700-v5.5-net-core-allow-fast-GRO-for-skbs-with-Ethernet-heade.patch
@@ -66,7 +66,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -5475,8 +5475,7 @@ static inline void skb_gro_reset_offset(
+@@ -5476,8 +5476,7 @@ static inline void skb_gro_reset_offset(
  	NAPI_GRO_CB(skb)->frag0 = NULL;
  	NAPI_GRO_CB(skb)->frag0_len = 0;
  

--- a/target/linux/generic/hack-5.4/250-netfilter_depends.patch
+++ b/target/linux/generic/hack-5.4/250-netfilter_depends.patch
@@ -9,7 +9,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/net/netfilter/Kconfig
 +++ b/net/netfilter/Kconfig
-@@ -228,7 +228,6 @@ config NF_CONNTRACK_FTP
+@@ -227,7 +227,6 @@ config NF_CONNTRACK_FTP
  
  config NF_CONNTRACK_H323
  	tristate "H.323 protocol support"
@@ -17,7 +17,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	depends on NETFILTER_ADVANCED
  	help
  	  H.323 is a VoIP signalling protocol from ITU-T. As one of the most
-@@ -1088,7 +1087,6 @@ config NETFILTER_XT_TARGET_SECMARK
+@@ -1087,7 +1086,6 @@ config NETFILTER_XT_TARGET_SECMARK
  
  config NETFILTER_XT_TARGET_TCPMSS
  	tristate '"TCPMSS" target support'

--- a/target/linux/generic/hack-5.4/550-loop-Report-EOPNOTSUPP-properly.patch
+++ b/target/linux/generic/hack-5.4/550-loop-Report-EOPNOTSUPP-properly.patch
@@ -27,7 +27,7 @@ Reviewed-by: Bart Van Assche <bvanassche@acm.org>
  		goto end_io;
  	}
  
-@@ -1973,7 +1973,10 @@ static void loop_handle_cmd(struct loop_
+@@ -1978,7 +1978,10 @@ static void loop_handle_cmd(struct loop_
   failed:
  	/* complete non-aio request */
  	if (!cmd->use_aio || ret) {

--- a/target/linux/generic/hack-5.4/650-netfilter-add-xt_OFFLOAD-target.patch
+++ b/target/linux/generic/hack-5.4/650-netfilter-add-xt_OFFLOAD-target.patch
@@ -47,7 +47,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	depends on !NF_CONNTRACK || NF_CONNTRACK
 --- a/net/netfilter/Kconfig
 +++ b/net/netfilter/Kconfig
-@@ -690,8 +690,6 @@ config NFT_FIB_NETDEV
+@@ -689,8 +689,6 @@ config NFT_FIB_NETDEV
  
  endif # NF_TABLES_NETDEV
  
@@ -56,7 +56,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  config NF_FLOW_TABLE_INET
  	tristate "Netfilter flow table mixed IPv4/IPv6 module"
  	depends on NF_FLOW_TABLE
-@@ -700,11 +698,12 @@ config NF_FLOW_TABLE_INET
+@@ -699,11 +697,12 @@ config NF_FLOW_TABLE_INET
  
  	  To compile it as a module, choose M here.
  
@@ -70,7 +70,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	help
  	  This option adds the flow table core infrastructure.
  
-@@ -993,6 +992,15 @@ config NETFILTER_XT_TARGET_NOTRACK
+@@ -992,6 +991,15 @@ config NETFILTER_XT_TARGET_NOTRACK
  	depends on NETFILTER_ADVANCED
  	select NETFILTER_XT_TARGET_CT
  

--- a/target/linux/generic/hack-5.4/721-phy_packets.patch
+++ b/target/linux/generic/hack-5.4/721-phy_packets.patch
@@ -56,7 +56,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
   */
 --- a/include/linux/skbuff.h
 +++ b/include/linux/skbuff.h
-@@ -2684,6 +2684,10 @@ static inline int pskb_trim(struct sk_bu
+@@ -2692,6 +2692,10 @@ static inline int pskb_trim(struct sk_bu
  	return (len < skb->len) ? __pskb_trim(skb, len) : 0;
  }
  
@@ -67,7 +67,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /**
   *	pskb_trim_unique - remove end from a paged unique (not cloned) buffer
   *	@skb: buffer to alter
-@@ -2815,16 +2819,6 @@ static inline struct sk_buff *dev_alloc_
+@@ -2823,16 +2827,6 @@ static inline struct sk_buff *dev_alloc_
  }
  
  

--- a/target/linux/generic/pending-5.4/640-netfilter-nf_flow_table-add-hardware-offload-support.patch
+++ b/target/linux/generic/pending-5.4/640-netfilter-nf_flow_table-add-hardware-offload-support.patch
@@ -128,7 +128,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  #define NFTA_FLOWTABLE_MAX	(__NFTA_FLOWTABLE_MAX - 1)
 --- a/net/netfilter/Kconfig
 +++ b/net/netfilter/Kconfig
-@@ -711,6 +711,15 @@ config NF_FLOW_TABLE
+@@ -710,6 +710,15 @@ config NF_FLOW_TABLE
  
  	  To compile it as a module, choose M here.
  

--- a/target/linux/generic/pending-5.4/655-increase_skb_pad.patch
+++ b/target/linux/generic/pending-5.4/655-increase_skb_pad.patch
@@ -9,7 +9,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/include/linux/skbuff.h
 +++ b/include/linux/skbuff.h
-@@ -2650,7 +2650,7 @@ static inline int pskb_network_may_pull(
+@@ -2658,7 +2658,7 @@ static inline int pskb_network_may_pull(
   * NET_IP_ALIGN(2) + ethernet_header(14) + IP_header(20/40) + ports(8)
   */
  #ifndef NET_SKB_PAD

--- a/target/linux/generic/pending-5.4/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
+++ b/target/linux/generic/pending-5.4/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
@@ -32,7 +32,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	__u16			tc_index;	/* traffic control index */
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -5541,6 +5541,9 @@ static enum gro_result dev_gro_receive(s
+@@ -5542,6 +5542,9 @@ static enum gro_result dev_gro_receive(s
  	int same_flow;
  	int grow;
  
@@ -42,7 +42,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (netif_elide_gro(skb->dev))
  		goto normal;
  
-@@ -7484,6 +7487,48 @@ static void __netdev_adjacent_dev_unlink
+@@ -7485,6 +7488,48 @@ static void __netdev_adjacent_dev_unlink
  					   &upper_dev->adj_list.lower);
  }
  
@@ -91,7 +91,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static int __netdev_upper_dev_link(struct net_device *dev,
  				   struct net_device *upper_dev, bool master,
  				   void *upper_priv, void *upper_info,
-@@ -7534,6 +7579,7 @@ static int __netdev_upper_dev_link(struc
+@@ -7535,6 +7580,7 @@ static int __netdev_upper_dev_link(struc
  	if (ret)
  		return ret;
  
@@ -99,7 +99,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	ret = call_netdevice_notifiers_info(NETDEV_CHANGEUPPER,
  					    &changeupper_info.info);
  	ret = notifier_to_errno(ret);
-@@ -7627,6 +7673,7 @@ void netdev_upper_dev_unlink(struct net_
+@@ -7628,6 +7674,7 @@ void netdev_upper_dev_unlink(struct net_
  
  	__netdev_adjacent_dev_unlink_neighbour(dev, upper_dev);
  
@@ -107,7 +107,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	call_netdevice_notifiers_info(NETDEV_CHANGEUPPER,
  				      &changeupper_info.info);
  
-@@ -8357,6 +8404,7 @@ int dev_set_mac_address(struct net_devic
+@@ -8358,6 +8405,7 @@ int dev_set_mac_address(struct net_devic
  	if (err)
  		return err;
  	dev->addr_assign_type = NET_ADDR_SET;

--- a/target/linux/layerscape/patches-5.4/303-core-0003-cgroup-let-a-symlink-too-be-created-with-a-cftype-fi.patch
+++ b/target/linux/layerscape/patches-5.4/303-core-0003-cgroup-let-a-symlink-too-be-created-with-a-cftype-fi.patch
@@ -37,7 +37,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  	/*
 --- a/kernel/cgroup/cgroup.c
 +++ b/kernel/cgroup/cgroup.c
-@@ -1467,8 +1467,8 @@ struct cgroup *task_cgroup_from_root(str
+@@ -1468,8 +1468,8 @@ struct cgroup *task_cgroup_from_root(str
  
  static struct kernfs_syscall_ops cgroup_kf_syscall_ops;
  
@@ -48,7 +48,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  {
  	struct cgroup_subsys *ss = cft->ss;
  
-@@ -1478,13 +1478,26 @@ static char *cgroup_file_name(struct cgr
+@@ -1479,13 +1479,26 @@ static char *cgroup_file_name(struct cgr
  
  		snprintf(buf, CGROUP_FILE_NAME_MAX, "%s%s.%s",
  			 dbg, cgroup_on_dfl(cgrp) ? ss->name : ss->legacy_name,
@@ -77,7 +77,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  /**
   * cgroup_file_mode - deduce file mode of a control file
   * @cft: the control file in question
-@@ -1643,6 +1656,9 @@ static void cgroup_rm_file(struct cgroup
+@@ -1644,6 +1657,9 @@ static void cgroup_rm_file(struct cgroup
  	}
  
  	kernfs_remove_by_name(cgrp->kn, cgroup_file_name(cgrp, cft, name));
@@ -87,7 +87,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  }
  
  /**
-@@ -3933,6 +3949,7 @@ static int cgroup_add_file(struct cgroup
+@@ -3994,6 +4010,7 @@ static int cgroup_add_file(struct cgroup
  {
  	char name[CGROUP_FILE_NAME_MAX];
  	struct kernfs_node *kn;
@@ -95,7 +95,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  	struct lock_class_key *key = NULL;
  	int ret;
  
-@@ -3963,6 +3980,14 @@ static int cgroup_add_file(struct cgroup
+@@ -4024,6 +4041,14 @@ static int cgroup_add_file(struct cgroup
  		spin_unlock_irq(&cgroup_file_kn_lock);
  	}
  

--- a/target/linux/layerscape/patches-5.4/303-core-0004-cgroup-bfq-revert-bfq.weight-symlink-change.patch
+++ b/target/linux/layerscape/patches-5.4/303-core-0004-cgroup-bfq-revert-bfq.weight-symlink-change.patch
@@ -39,7 +39,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  	/*
 --- a/kernel/cgroup/cgroup.c
 +++ b/kernel/cgroup/cgroup.c
-@@ -1467,8 +1467,8 @@ struct cgroup *task_cgroup_from_root(str
+@@ -1468,8 +1468,8 @@ struct cgroup *task_cgroup_from_root(str
  
  static struct kernfs_syscall_ops cgroup_kf_syscall_ops;
  
@@ -50,7 +50,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  {
  	struct cgroup_subsys *ss = cft->ss;
  
-@@ -1478,26 +1478,13 @@ static char *cgroup_fill_name(struct cgr
+@@ -1479,26 +1479,13 @@ static char *cgroup_fill_name(struct cgr
  
  		snprintf(buf, CGROUP_FILE_NAME_MAX, "%s%s.%s",
  			 dbg, cgroup_on_dfl(cgrp) ? ss->name : ss->legacy_name,
@@ -79,7 +79,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  /**
   * cgroup_file_mode - deduce file mode of a control file
   * @cft: the control file in question
-@@ -1656,9 +1643,6 @@ static void cgroup_rm_file(struct cgroup
+@@ -1657,9 +1644,6 @@ static void cgroup_rm_file(struct cgroup
  	}
  
  	kernfs_remove_by_name(cgrp->kn, cgroup_file_name(cgrp, cft, name));
@@ -89,7 +89,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  }
  
  /**
-@@ -3949,7 +3933,6 @@ static int cgroup_add_file(struct cgroup
+@@ -4010,7 +3994,6 @@ static int cgroup_add_file(struct cgroup
  {
  	char name[CGROUP_FILE_NAME_MAX];
  	struct kernfs_node *kn;
@@ -97,7 +97,7 @@ Signed-off-by: Li Yang <leoyang.li@nxp.com>
  	struct lock_class_key *key = NULL;
  	int ret;
  
-@@ -3980,14 +3963,6 @@ static int cgroup_add_file(struct cgroup
+@@ -4041,14 +4024,6 @@ static int cgroup_add_file(struct cgroup
  		spin_unlock_irq(&cgroup_file_kn_lock);
  	}
  

--- a/target/linux/layerscape/patches-5.4/819-uart-0001-tty-serial-lpuart-add-power-domain-support.patch
+++ b/target/linux/layerscape/patches-5.4/819-uart-0001-tty-serial-lpuart-add-power-domain-support.patch
@@ -27,7 +27,7 @@ Signed-off-by: Fugang Duan <fugang.duan@nxp.com>
  #include <linux/serial_core.h>
  #include <linux/slab.h>
  #include <linux/tty_flip.h>
-@@ -2391,6 +2393,54 @@ static struct uart_driver lpuart_reg = {
+@@ -2392,6 +2394,54 @@ static struct uart_driver lpuart_reg = {
  	.cons		= LPUART_CONSOLE,
  };
  
@@ -82,7 +82,7 @@ Signed-off-by: Fugang Duan <fugang.duan@nxp.com>
  static int lpuart_probe(struct platform_device *pdev)
  {
  	const struct of_device_id *of_id = of_match_device(lpuart_dt_ids,
-@@ -2428,6 +2478,10 @@ static int lpuart_probe(struct platform_
+@@ -2429,6 +2479,10 @@ static int lpuart_probe(struct platform_
  
  	sport->port.rs485_config = lpuart_config_rs485;
  

--- a/target/linux/layerscape/patches-5.4/819-uart-0005-tty-serial-fsl_lpuart-enable-dma-mode-for-imx8qxp.patch
+++ b/target/linux/layerscape/patches-5.4/819-uart-0005-tty-serial-fsl_lpuart-enable-dma-mode-for-imx8qxp.patch
@@ -536,7 +536,7 @@ Signed-off-by: Fugang Duan <fugang.duan@nxp.com>
  		lpuart_dma_rx_free(&sport->port);
  	}
  
-@@ -2480,6 +2636,10 @@ static int lpuart_probe(struct platform_
+@@ -2481,6 +2637,10 @@ static int lpuart_probe(struct platform_
  	sport->port.dev = &pdev->dev;
  	sport->port.type = PORT_LPUART;
  	sport->devtype = sdata->devtype;
@@ -547,7 +547,7 @@ Signed-off-by: Fugang Duan <fugang.duan@nxp.com>
  	ret = platform_get_irq(pdev, 0);
  	if (ret < 0)
  		return ret;
-@@ -2630,7 +2790,7 @@ static int lpuart_suspend(struct device
+@@ -2631,7 +2791,7 @@ static int lpuart_suspend(struct device
  		 * Rx DMA path before suspend and start Rx DMA path on resume.
  		 */
  		if (irq_wake) {

--- a/target/linux/layerscape/patches-5.4/819-uart-0008-MLK-21445-serial-fsl_lpuart-do-HW-reset-for-communic.patch
+++ b/target/linux/layerscape/patches-5.4/819-uart-0008-MLK-21445-serial-fsl_lpuart-do-HW-reset-for-communic.patch
@@ -105,7 +105,7 @@ Signed-off-by: Shrikant Bobade <Shrikant_Bobade@mentor.com>
  static void lpuart_stop_tx(struct uart_port *port)
  {
  	unsigned char temp;
-@@ -2723,6 +2765,10 @@ static int lpuart_probe(struct platform_
+@@ -2724,6 +2766,10 @@ static int lpuart_probe(struct platform_
  	if (ret)
  		goto failed_attach_port;
  
@@ -116,7 +116,7 @@ Signed-off-by: Shrikant Bobade <Shrikant_Bobade@mentor.com>
  	uart_get_rs485_mode(&pdev->dev, &sport->port.rs485);
  
  	if (sport->port.rs485.flags & SER_RS485_RX_DURING_TX)
-@@ -2746,6 +2792,8 @@ static int lpuart_probe(struct platform_
+@@ -2747,6 +2793,8 @@ static int lpuart_probe(struct platform_
  
  	return 0;
  

--- a/target/linux/layerscape/patches-5.4/819-uart-0009-MLK-17133-02-tty-serial-lpuart-add-runtime-pm-suppor.patch
+++ b/target/linux/layerscape/patches-5.4/819-uart-0009-MLK-17133-02-tty-serial-lpuart-add-runtime-pm-suppor.patch
@@ -43,7 +43,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  /* return TIOCSER_TEMT when transmitter is not busy */
  static unsigned int lpuart_tx_empty(struct uart_port *port)
  {
-@@ -2280,6 +2295,7 @@ static const struct uart_ops lpuart_pops
+@@ -2281,6 +2296,7 @@ static const struct uart_ops lpuart_pops
  	.break_ctl	= lpuart_break_ctl,
  	.startup	= lpuart_startup,
  	.shutdown	= lpuart_shutdown,
@@ -51,7 +51,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  	.set_termios	= lpuart_set_termios,
  	.type		= lpuart_type,
  	.request_port	= lpuart_request_port,
-@@ -2304,6 +2320,7 @@ static const struct uart_ops lpuart32_po
+@@ -2305,6 +2321,7 @@ static const struct uart_ops lpuart32_po
  	.break_ctl	= lpuart32_break_ctl,
  	.startup	= lpuart32_startup,
  	.shutdown	= lpuart32_shutdown,
@@ -59,7 +59,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  	.set_termios	= lpuart32_set_termios,
  	.type		= lpuart_type,
  	.request_port	= lpuart_request_port,
-@@ -2761,6 +2778,11 @@ static int lpuart_probe(struct platform_
+@@ -2762,6 +2779,11 @@ static int lpuart_probe(struct platform_
  	if (ret)
  		goto failed_irq_request;
  
@@ -71,7 +71,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  	ret = uart_add_one_port(&lpuart_reg, &sport->port);
  	if (ret)
  		goto failed_attach_port;
-@@ -2795,6 +2817,9 @@ static int lpuart_probe(struct platform_
+@@ -2796,6 +2818,9 @@ static int lpuart_probe(struct platform_
  failed_reset:
  	uart_remove_one_port(&lpuart_reg, &sport->port);
  failed_attach_port:
@@ -81,7 +81,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  failed_irq_request:
  	lpuart_disable_clks(sport);
  	return ret;
-@@ -2814,15 +2839,41 @@ static int lpuart_remove(struct platform
+@@ -2815,15 +2840,41 @@ static int lpuart_remove(struct platform
  	if (sport->dma_rx_chan)
  		dma_release_channel(sport->dma_rx_chan);
  
@@ -123,7 +123,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  
  	if (lpuart_is_32(sport)) {
  		/* disable Rx/Tx and interrupts */
-@@ -2836,10 +2887,14 @@ static int lpuart_suspend(struct device
+@@ -2837,10 +2888,14 @@ static int lpuart_suspend(struct device
  		writeb(temp, sport->port.membase + UARTCR2);
  	}
  
@@ -138,7 +138,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  
  	if (sport->lpuart_dma_rx_use) {
  		/*
-@@ -2870,9 +2925,6 @@ static int lpuart_suspend(struct device
+@@ -2871,9 +2926,6 @@ static int lpuart_suspend(struct device
  		dmaengine_terminate_all(sport->dma_tx_chan);
  	}
  
@@ -148,7 +148,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  	return 0;
  }
  
-@@ -2880,9 +2932,11 @@ static int lpuart_resume(struct device *
+@@ -2881,9 +2933,11 @@ static int lpuart_resume(struct device *
  {
  	struct lpuart_port *sport = dev_get_drvdata(dev);
  	bool irq_wake = irqd_is_wakeup_set(irq_get_irq_data(sport->port.irq));
@@ -162,7 +162,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  
  	if (lpuart_is_32(sport))
  		lpuart32_setup_watermark_enable(sport);
-@@ -2903,13 +2957,23 @@ static int lpuart_resume(struct device *
+@@ -2904,13 +2958,23 @@ static int lpuart_resume(struct device *
  	if (lpuart_is_32(sport))
  		lpuart32_configure(sport);
  
@@ -188,7 +188,7 @@ Reviewed-by: Robin Gong <yibin.gong@nxp.com>
  
  static struct platform_driver lpuart_driver = {
  	.probe		= lpuart_probe,
-@@ -2917,7 +2981,7 @@ static struct platform_driver lpuart_dri
+@@ -2918,7 +2982,7 @@ static struct platform_driver lpuart_dri
  	.driver		= {
  		.name	= "fsl-lpuart",
  		.of_match_table = lpuart_dt_ids,

--- a/target/linux/layerscape/patches-5.4/819-uart-0010-tty-serial-lpuart-enable-wakeup-source-for-lpuart.patch
+++ b/target/linux/layerscape/patches-5.4/819-uart-0010-tty-serial-lpuart-enable-wakeup-source-for-lpuart.patch
@@ -117,7 +117,7 @@ Signed-off-by: Fugang Duan <fugang.duan@nxp.com>
  	return 0;
  }
  
-@@ -2864,108 +2878,205 @@ static int lpuart_runtime_resume(struct
+@@ -2865,108 +2879,205 @@ static int lpuart_runtime_resume(struct
  	return lpuart_enable_clks(sport);
  };
  

--- a/target/linux/layerscape/patches-5.4/819-uart-0011-serial-fsl_lpuart-enable-two-stop-bits.patch
+++ b/target/linux/layerscape/patches-5.4/819-uart-0011-serial-fsl_lpuart-enable-two-stop-bits.patch
@@ -39,7 +39,7 @@ Signed-off-by: Fugang Duan <fugang.duan@nxp.com>
  
  	/* parity must be enabled when CS7 to match 8-bits format */
  	if ((termios->c_cflag & CSIZE) == CS7)
-@@ -2243,6 +2246,7 @@ lpuart32_set_termios(struct uart_port *p
+@@ -2244,6 +2247,7 @@ lpuart32_set_termios(struct uart_port *p
  	lpuart32_write(&sport->port, old_ctrl & ~(UARTCTRL_TE | UARTCTRL_RE),
  		       UARTCTRL);
  

--- a/target/linux/layerscape/patches-5.4/819-uart-0013-LF-484-tty-serial-lpuart-support-UPIO_MEM32-for-lpua.patch
+++ b/target/linux/layerscape/patches-5.4/819-uart-0013-LF-484-tty-serial-lpuart-support-UPIO_MEM32-for-lpua.patch
@@ -24,7 +24,7 @@ Signed-off-by: Peng Fan <peng.fan@nxp.com>
 
 --- a/drivers/tty/serial/fsl_lpuart.c
 +++ b/drivers/tty/serial/fsl_lpuart.c
-@@ -2614,7 +2614,9 @@ static int __init lpuart32_early_console
+@@ -2615,7 +2615,9 @@ static int __init lpuart32_early_console
  	if (!device->port.membase)
  		return -ENODEV;
  

--- a/target/linux/layerscape/patches-5.4/820-usb-0004-usb-dwc3-use-suspend-clock-from-dt-to-set-power-down.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0004-usb-dwc3-use-suspend-clock-from-dt-to-set-power-down.patch
@@ -15,7 +15,7 @@ Signed-off-by: Li Jun <jun.li@nxp.com>
 
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -900,6 +900,25 @@ static void dwc3_set_incr_burst_type(str
+@@ -901,6 +901,25 @@ static void dwc3_set_incr_burst_type(str
  	dwc3_writel(dwc->regs, DWC3_GSBUSCFG0, cfg);
  }
  
@@ -41,7 +41,7 @@ Signed-off-by: Li Jun <jun.li@nxp.com>
  /**
   * dwc3_core_init - Low-level initialization of DWC3 Core
   * @dwc: Pointer to our controller context structure
-@@ -924,6 +943,8 @@ static int dwc3_core_init(struct dwc3 *d
+@@ -925,6 +944,8 @@ static int dwc3_core_init(struct dwc3 *d
  			dwc->maximum_speed = USB_SPEED_HIGH;
  	}
  

--- a/target/linux/layerscape/patches-5.4/820-usb-0005-usb-dwc3-add-otg-properties-update.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0005-usb-dwc3-add-otg-properties-update.patch
@@ -16,7 +16,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
 
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -1269,6 +1269,17 @@ static void dwc3_get_properties(struct d
+@@ -1270,6 +1270,17 @@ static void dwc3_get_properties(struct d
  
  	dwc->maximum_speed = usb_get_maximum_speed(dev);
  	dwc->dr_mode = usb_get_dr_mode(dev);

--- a/target/linux/layerscape/patches-5.4/820-usb-0009-usb-dwc3-Add-workaround-for-host-mode-VBUS-glitch-wh.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0009-usb-dwc3-Add-workaround-for-host-mode-VBUS-glitch-wh.patch
@@ -32,7 +32,7 @@ Reviewed-by: Peter Chen <peter.chen@nxp.com>
 
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -1364,6 +1364,9 @@ static void dwc3_get_properties(struct d
+@@ -1365,6 +1365,9 @@ static void dwc3_get_properties(struct d
  	dwc->dis_split_quirk = device_property_read_bool(dev,
  				"snps,dis-split-quirk");
  
@@ -64,15 +64,10 @@ Reviewed-by: Peter Chen <peter.chen@nxp.com>
  
 --- a/drivers/usb/dwc3/host.c
 +++ b/drivers/usb/dwc3/host.c
-@@ -9,8 +9,49 @@
+@@ -16,6 +16,44 @@ static const struct xhci_plat_priv dwc3_
+ 	.quirks = XHCI_SKIP_PHY_INIT,
+ };
  
- #include <linux/platform_device.h>
- 
-+#include "../host/xhci.h"
-+
- #include "core.h"
- 
-+
 +#define XHCI_HCSPARAMS1		0x4
 +#define XHCI_PORTSC_BASE	0x400
 +
@@ -114,7 +109,7 @@ Reviewed-by: Peter Chen <peter.chen@nxp.com>
  static int dwc3_host_get_irq(struct dwc3 *dwc)
  {
  	struct platform_device	*dwc3_pdev = to_platform_device(dwc->dev);
-@@ -50,6 +91,13 @@ int dwc3_host_init(struct dwc3 *dwc)
+@@ -55,6 +93,13 @@ int dwc3_host_init(struct dwc3 *dwc)
  	struct platform_device	*dwc3_pdev = to_platform_device(dwc->dev);
  	int			prop_idx = 0;
  

--- a/target/linux/layerscape/patches-5.4/820-usb-0010-MLK-22675-usb-dwc3-host-disable-park-mode.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0010-MLK-22675-usb-dwc3-host-disable-park-mode.patch
@@ -54,7 +54,7 @@ Signed-off-by: Li Jun <jun.li@nxp.com>
 
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -1039,6 +1039,21 @@ static int dwc3_core_init(struct dwc3 *d
+@@ -1040,6 +1040,21 @@ static int dwc3_core_init(struct dwc3 *d
  		reg |= DWC3_GUCTL_HSTINAUTORETRY;
  
  		dwc3_writel(dwc->regs, DWC3_GUCTL, reg);

--- a/target/linux/layerscape/patches-5.4/820-usb-0011-usb-dwc3-Add-cache-type-configuration-support.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0011-usb-dwc3-Add-cache-type-configuration-support.patch
@@ -43,7 +43,7 @@ Reviewed-by: Jun Li <jun.li@nxp.com>
 
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -919,6 +919,54 @@ static void dwc3_set_power_down_clk_scal
+@@ -920,6 +920,54 @@ static void dwc3_set_power_down_clk_scal
  	dwc3_writel(dwc->regs, DWC3_GCTL, reg);
  }
  
@@ -98,7 +98,7 @@ Reviewed-by: Jun Li <jun.li@nxp.com>
  /**
   * dwc3_core_init - Low-level initialization of DWC3 Core
   * @dwc: Pointer to our controller context structure
-@@ -979,6 +1027,10 @@ static int dwc3_core_init(struct dwc3 *d
+@@ -980,6 +1028,10 @@ static int dwc3_core_init(struct dwc3 *d
  
  	dwc3_set_incr_burst_type(dwc);
  
@@ -109,7 +109,7 @@ Reviewed-by: Jun Li <jun.li@nxp.com>
  	usb_phy_set_suspend(dwc->usb2_phy, 0);
  	usb_phy_set_suspend(dwc->usb3_phy, 0);
  	ret = phy_power_on(dwc->usb2_generic_phy);
-@@ -1932,12 +1984,9 @@ static const struct dev_pm_ops dwc3_dev_
+@@ -1933,12 +1985,9 @@ static const struct dev_pm_ops dwc3_dev_
  
  #ifdef CONFIG_OF
  static const struct of_device_id of_dwc3_match[] = {

--- a/target/linux/layerscape/patches-5.4/820-usb-0015-MLK-17380-4-usb-host-xhci-add-EH-SINGLE_STEP_SET_FEA.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0015-MLK-17380-4-usb-host-xhci-add-EH-SINGLE_STEP_SET_FEA.patch
@@ -174,7 +174,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
   * bursts that are required to move all packets in this TD.  Only SuperSpeed
 --- a/drivers/usb/host/xhci.c
 +++ b/drivers/usb/host/xhci.c
-@@ -5423,6 +5423,7 @@ static const struct hc_driver xhci_hc_dr
+@@ -5414,6 +5414,7 @@ static const struct hc_driver xhci_hc_dr
  	.disable_usb3_lpm_timeout =	xhci_disable_usb3_lpm_timeout,
  	.find_raw_port_number =	xhci_find_raw_port_number,
  	.clear_tt_buffer_complete = xhci_clear_tt_buffer_complete,
@@ -184,8 +184,8 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  void xhci_init_driver(struct hc_driver *drv,
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -2159,6 +2159,16 @@ void xhci_set_port_power(struct xhci_hcd
- 			 bool on, unsigned long *flags);
+@@ -2157,6 +2157,16 @@ int xhci_find_raw_port_number(struct usb
+ struct xhci_hub *xhci_get_rhub(struct usb_hcd *hcd);
  
  void xhci_hc_died(struct xhci_hcd *xhci);
 +#ifdef CONFIG_USB_HCD_TEST_MODE

--- a/target/linux/layerscape/patches-5.4/820-usb-0016-MLK-16735-usb-host-add-XHCI_CDNS_HOST-flag.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0016-MLK-16735-usb-host-add-XHCI_CDNS_HOST-flag.patch
@@ -21,7 +21,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
 
 --- a/drivers/usb/host/xhci.c
 +++ b/drivers/usb/host/xhci.c
-@@ -193,7 +193,7 @@ int xhci_reset(struct xhci_hcd *xhci, u6
+@@ -195,7 +195,7 @@ int xhci_reset(struct xhci_hcd *xhci, u6
  	 * Without this delay, the subsequent HC register access,
  	 * may result in a system hang very rarely.
  	 */

--- a/target/linux/layerscape/patches-5.4/820-usb-0018-MLK-18794-1-usb-host-xhci-add-.bus_suspend-override.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0018-MLK-18794-1-usb-host-xhci-add-.bus_suspend-override.patch
@@ -24,7 +24,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
 
 --- a/drivers/usb/host/xhci.c
 +++ b/drivers/usb/host/xhci.c
-@@ -5444,6 +5444,8 @@ void xhci_init_driver(struct hc_driver *
+@@ -5435,6 +5435,8 @@ void xhci_init_driver(struct hc_driver *
  			drv->check_bandwidth = over->check_bandwidth;
  		if (over->reset_bandwidth)
  			drv->reset_bandwidth = over->reset_bandwidth;

--- a/target/linux/layerscape/patches-5.4/820-usb-0021-MLK-22099-usb-host-xhci-do-warm-reset-for-link-state.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0021-MLK-22099-usb-host-xhci-do-warm-reset-for-link-state.patch
@@ -16,7 +16,7 @@ Signed-off-by: Li Jun <jun.li@nxp.com>
 
 --- a/drivers/usb/host/xhci-hub.c
 +++ b/drivers/usb/host/xhci-hub.c
-@@ -1743,7 +1743,8 @@ static bool xhci_port_missing_cas_quirk(
+@@ -1754,7 +1754,8 @@ static bool xhci_port_missing_cas_quirk(
  		return false;
  
  	if (((portsc & PORT_PLS_MASK) != XDEV_POLLING) &&

--- a/target/linux/layerscape/patches-5.4/820-usb-0024-LF-387-1-Revert-usb-dwc3-Add-cache-type-configuratio.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0024-LF-387-1-Revert-usb-dwc3-Add-cache-type-configuratio.patch
@@ -15,7 +15,7 @@ Signed-off-by: Ran Wang <ran.wang_1@nxp.com>
 
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -919,54 +919,6 @@ static void dwc3_set_power_down_clk_scal
+@@ -920,54 +920,6 @@ static void dwc3_set_power_down_clk_scal
  	dwc3_writel(dwc->regs, DWC3_GCTL, reg);
  }
  
@@ -70,7 +70,7 @@ Signed-off-by: Ran Wang <ran.wang_1@nxp.com>
  /**
   * dwc3_core_init - Low-level initialization of DWC3 Core
   * @dwc: Pointer to our controller context structure
-@@ -1027,10 +979,6 @@ static int dwc3_core_init(struct dwc3 *d
+@@ -1028,10 +980,6 @@ static int dwc3_core_init(struct dwc3 *d
  
  	dwc3_set_incr_burst_type(dwc);
  
@@ -81,7 +81,7 @@ Signed-off-by: Ran Wang <ran.wang_1@nxp.com>
  	usb_phy_set_suspend(dwc->usb2_phy, 0);
  	usb_phy_set_suspend(dwc->usb3_phy, 0);
  	ret = phy_power_on(dwc->usb2_generic_phy);
-@@ -1984,9 +1932,12 @@ static const struct dev_pm_ops dwc3_dev_
+@@ -1985,9 +1933,12 @@ static const struct dev_pm_ops dwc3_dev_
  
  #ifdef CONFIG_OF
  static const struct of_device_id of_dwc3_match[] = {

--- a/target/linux/layerscape/patches-5.4/820-usb-0025-LF-387-4-usb-dwc3-Add-cache-type-configuration-suppo.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0025-LF-387-4-usb-dwc3-Add-cache-type-configuration-suppo.patch
@@ -43,7 +43,7 @@ Reviewed-by: Jun Li <jun.li@nxp.com>
 
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -919,6 +919,53 @@ static void dwc3_set_power_down_clk_scal
+@@ -920,6 +920,53 @@ static void dwc3_set_power_down_clk_scal
  	dwc3_writel(dwc->regs, DWC3_GCTL, reg);
  }
  
@@ -97,7 +97,7 @@ Reviewed-by: Jun Li <jun.li@nxp.com>
  /**
   * dwc3_core_init - Low-level initialization of DWC3 Core
   * @dwc: Pointer to our controller context structure
-@@ -979,6 +1026,10 @@ static int dwc3_core_init(struct dwc3 *d
+@@ -980,6 +1027,10 @@ static int dwc3_core_init(struct dwc3 *d
  
  	dwc3_set_incr_burst_type(dwc);
  
@@ -108,7 +108,7 @@ Reviewed-by: Jun Li <jun.li@nxp.com>
  	usb_phy_set_suspend(dwc->usb2_phy, 0);
  	usb_phy_set_suspend(dwc->usb3_phy, 0);
  	ret = phy_power_on(dwc->usb2_generic_phy);
-@@ -1932,12 +1983,16 @@ static const struct dev_pm_ops dwc3_dev_
+@@ -1933,12 +1984,16 @@ static const struct dev_pm_ops dwc3_dev_
  
  #ifdef CONFIG_OF
  static const struct of_device_id of_dwc3_match[] = {


### PR DESCRIPTION
Manually adapted:
  layerscape/patches-5.4/820-usb-0009-usb-dwc3-Add-workaround-for-host-mode-VBUS-glitch-wh.patch

Compile-tested: x86/64
Run-tested: x86/64

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
