### PR TITLE
kernel: add missing symbol

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -422,6 +422,11 @@ config KERNEL_KPROBE_EVENTS
 	bool
 	default y if KERNEL_KPROBES
 
+config KERNEL_BPF_KPROBE_OVERRIDE
+	bool
+	depends on KERNEL_KPROBES
+	default n
+
 config KERNEL_AIO
 	bool "Compile the kernel with asynchronous IO support"
 	default y if !SMALL_FLASH


### PR DESCRIPTION
Enabling KERNEL_KPROBES exposes KERNEL_BPF_KPROBE_OVERRIDE. Add a build option for it to fix build failures with KERNEL_KPROBES enabled.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
(cherry picked from commit 500c37c56ff60b46c30bb0ea7c92676bea23331a)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
