### PR TITLE
mac80211: backport security fix and disable MBSSID support

### DIFF
--- a/package/kernel/mac80211/patches/subsys/396-wifi-mac80211-fix-crash-in-beacon-protection-for-P2P.patch
+++ b/package/kernel/mac80211/patches/subsys/396-wifi-mac80211-fix-crash-in-beacon-protection-for-P2P.patch
@@ -1,0 +1,52 @@
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Wed, 5 Oct 2022 21:24:10 +0200
+Subject: [PATCH] wifi: mac80211: fix crash in beacon protection for
+ P2P-device
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit b2d03cabe2b2e150ff5a381731ea0355459be09f upstream.
+
+If beacon protection is active but the beacon cannot be
+decrypted or is otherwise malformed, we call the cfg80211
+API to report this to userspace, but that uses a netdev
+pointer, which isn't present for P2P-Device. Fix this to
+call it only conditionally to ensure cfg80211 won't crash
+in the case of P2P-Device.
+
+This fixes CVE-2022-42722.
+
+Reported-by: Sönke Huster <shuster@seemoo.tu-darmstadt.de>
+Fixes: 9eaf183af741 ("mac80211: Report beacon protection failures to user space")
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+
+--- a/net/mac80211/rx.c
++++ b/net/mac80211/rx.c
+@@ -1972,10 +1972,11 @@ ieee80211_rx_h_decrypt(struct ieee80211_
+ 
+ 		if (mmie_keyidx < NUM_DEFAULT_KEYS + NUM_DEFAULT_MGMT_KEYS ||
+ 		    mmie_keyidx >= NUM_DEFAULT_KEYS + NUM_DEFAULT_MGMT_KEYS +
+-		    NUM_DEFAULT_BEACON_KEYS) {
+-			cfg80211_rx_unprot_mlme_mgmt(rx->sdata->dev,
+-						     skb->data,
+-						     skb->len);
++				   NUM_DEFAULT_BEACON_KEYS) {
++			if (rx->sdata->dev)
++				cfg80211_rx_unprot_mlme_mgmt(rx->sdata->dev,
++							     skb->data,
++							     skb->len);
+ 			return RX_DROP_MONITOR; /* unexpected BIP keyidx */
+ 		}
+ 
+@@ -2123,7 +2124,8 @@ ieee80211_rx_h_decrypt(struct ieee80211_
+ 	/* either the frame has been decrypted or will be dropped */
+ 	status->flag |= RX_FLAG_DECRYPTED;
+ 
+-	if (unlikely(ieee80211_is_beacon(fc) && result == RX_DROP_UNUSABLE))
++	if (unlikely(ieee80211_is_beacon(fc) && result == RX_DROP_UNUSABLE &&
++		     rx->sdata->dev))
+ 		cfg80211_rx_unprot_mlme_mgmt(rx->sdata->dev,
+ 					     skb->data, skb->len);
+ 

--- a/package/kernel/mac80211/patches/subsys/397-disable-mbssid.patch
+++ b/package/kernel/mac80211/patches/subsys/397-disable-mbssid.patch
@@ -1,0 +1,44 @@
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1406,6 +1406,7 @@ static size_t ieee802_11_find_bssid_prof
+ 	if (!bss_bssid || !transmitter_bssid)
+ 		return profile_len;
+ 
++	return 0;
+ 	for_each_element_id(elem, WLAN_EID_MULTIPLE_BSSID, start, len) {
+ 		if (elem->datalen < 2)
+ 			continue;
+--- a/net/wireless/scan.c
++++ b/net/wireless/scan.c
+@@ -1982,6 +1982,7 @@ static const struct element
+ 	const struct element *next_mbssid;
+ 	const struct element *next_sub;
+ 
++	return NULL;
+ 	next_mbssid = cfg80211_find_elem(WLAN_EID_MULTIPLE_BSSID,
+ 					 mbssid_end,
+ 					 ielen - (mbssid_end - ie));
+@@ -2063,6 +2064,7 @@ static void cfg80211_parse_mbssid_data(s
+ 	u16 capability;
+ 	struct cfg80211_bss *bss;
+ 
++	return;
+ 	if (!non_tx_data)
+ 		return;
+ 	if (!cfg80211_find_ie(WLAN_EID_MULTIPLE_BSSID, ie, ielen))
+@@ -2221,6 +2223,7 @@ cfg80211_update_notlisted_nontrans(struc
+ 	const struct cfg80211_bss_ies *old;
+ 	u8 cpy_len;
+ 
++	return;
+ 	lockdep_assert_held(&wiphy_to_rdev(wiphy)->bss_lock);
+ 
+ 	ie = mgmt->u.probe_resp.variable;
+@@ -2436,6 +2439,7 @@ cfg80211_inform_bss_frame_data(struct wi
+ 
+ 	res = cfg80211_inform_single_bss_frame_data(wiphy, data, mgmt,
+ 						    len, gfp);
++	return res;
+ 	if (!res || !wiphy->support_mbssid ||
+ 	    !cfg80211_find_ie(WLAN_EID_MULTIPLE_BSSID, ie, ielen))
+ 		return res;


### PR DESCRIPTION
Fixes: CVE-2022-41674
Fixes: CVE-2022-42719
Fixes: CVE-2022-42720
Fixes: CVE-2022-42721
Fixes: CVE-2022-42722
Signed-off-by: Felix Fietkau <nbd@nbd.name>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
