### PR TITLE
ramips: Correct Unielec 01 and 06 dts wan macaddr byte location

### DIFF
--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
@@ -52,8 +52,8 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_e000>;
+&wan {
+	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
@@ -57,8 +57,8 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_e000>;
+&wan {
+	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-64m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-64m.dts
@@ -58,8 +58,8 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_e000>;
+&wan {
+	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
 


### PR DESCRIPTION
Recent backport patch b5cb5f352d3133ac8384275be7d47264ad135e74 had missed changing the macaddr_factory address location.

This patch corrects the address location.

Fixes: b5cb5f352d31 ("ramips: fix WAN mac address allocation for Unielec 01 and 06 models")
Signed-off-by: David Bentham <db260179@gmail.com>
[Fix dts node name too]
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
