### PR TITLE
ath79: fix Teltonika RUT230 v1 MAC assignment

### DIFF
--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -10,7 +10,7 @@
 	compatible = "teltonika,rut230-v1", "qca,ar9331";
 
 	aliases {
-		label-mac-device = &wmac;
+		label-mac-device = &eth1;
 		led-boot = &led_ss0;
 		led-failsafe = &led_ss0;
 		led-upgrade = &led_ss0;
@@ -111,6 +111,7 @@
 
 	nvmem-cells = <&macaddr_config_0>;
 	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
 };
 
 &eth1 {
@@ -118,7 +119,6 @@
 
 	nvmem-cells = <&macaddr_config_0>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &spi {


### PR DESCRIPTION
The MAC-Address setup for the Teltonika RUT230 v1 was swapped for the LAN / WAN ports. Also the Label-MAC was assigned incorrect, as the WiFi MAC is printed on the case as part of the SSID, however only the LAN MAC-Address is designated as a MAC-Address.

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit 4c0919839d77ca33a6305116e2ff67234fb07514)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
