### PR TITLE
ramips: fix lzma-loader for buffalo_WSR_600DHP

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -306,6 +306,7 @@ TARGET_DEVICES += buffalo_wsr-2533dhpl
 
 define Device/buffalo_wsr-600dhp
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WSR-600DHP


### PR DESCRIPTION
This fixes a well known "LZMA ERROR 1" error, reported previously on numerous of similar devices.

Fixes: #11919
Signed-off-by: Haoan Li <lihaoan1001@163.com>
(cherry picked from commit c7b484f3647c58da2f86395228a9927290a6f6ed)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
