### PR TITLE
build: generate index.json

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -92,6 +92,10 @@ $(curdir)/index: FORCE
 			$(call ERROR_MESSAGE,WARNING: Applying padding in $$d/Packages to workaround usign SHA-512 bug!); \
 			{ echo ""; echo ""; } >> Packages;; \
 		esac; \
+		echo -n '{"architecture": "$(ARCH_PACKAGES)", "packages":{' > index.json; \
+		sed -n -e 's/^Package: \(.*\)$$/"\1":/p' -e 's/^Version: \(.*\)$$/"\1",/p' Packages | tr '\n' ' ' >> index.json; \
+		echo '}}' >> index.json; \
+		sed -i 's/, }}/}}/' index.json; \
 		gzip -9nc Packages > Packages.gz; \
 	); done
 ifdef CONFIG_SIGNED_PACKAGES


### PR DESCRIPTION
The index.json file lies next to Packages index files and contains a json dict with the package architecture and a dict of package names and versions.

This can be used for downstream project to know what packages in which versions are available.

Signed-off-by: Paul Spooren <mail@aparcar.org>
(cherry picked from commit 218ce40cd738f3373438aab82467807a8707fb9c)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
